### PR TITLE
fix: use relative API path for summaries

### DIFF
--- a/components/ArticleList.tsx
+++ b/components/ArticleList.tsx
@@ -18,7 +18,10 @@ export default function ArticleList() {
 
   const handleSummaryClick = async (level: string, summary: string) => {
     try {
-      const res = await fetch('/api/summarize', {
+      // Use a relative path so deployments with a basePath work correctly
+      // (e.g. GitHub Pages where the app lives under /signal).
+      // An absolute path would ignore the base and lead to 405 errors.
+      const res = await fetch('api/summarize', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- fix summary API fetch path to respect deployed basePath
- avoid 405 errors and React warnings when generating summaries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4c70aaa38832a8dd7c33f3aed00d3